### PR TITLE
Fixes, prettifying, Docker provisioning fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Filip Dimovski
+Portions Copyright (c) 2017 Igor Šarčević
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -48,11 +48,8 @@ $ ./install
 
 # Get inside the machine and start working :)
 $ rxb
-```
-* The script will request your password because it will need to install
-  some tools to your system, such as VirtualBox and Vagrant, if needed
-```sh
-# Stop the machine
+
+# Stop the machine (once you exit the SSH session)
 $ rxh
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 RexBox is a Vagrant box designed to allow developers to get started
 with their work as soon as possible. Based on Ubuntu 14.04.5 LTS 64-bit,
 it provides a solid base with the latest versions of programming
-languages and various tools, such as Erlang, Elixir, Ruby, AWS-cli, etc.
+languages and various tools, such as Erlang, Elixir, Ruby, etc.
 
 Partly based on shiroyasha's [boxbox](https://github.com/shiroyasha/boxbox).
 
@@ -11,7 +11,8 @@ Partly based on shiroyasha's [boxbox](https://github.com/shiroyasha/boxbox).
 ## Requirements
 
 * Ubuntu 14.04 LTS or 16.04 LTS, 64-bit only
-* VirtualBox and its Extension Pack >= 5.0
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and its
+  Extension Pack >= 5.0
 * Latest [Vagrant](https://www.vagrantup.com/downloads.html)
 * If you intend to use RexBox on other Linux distributions or macOS,
   make sure you install the latest VirtualBox and Vagrant on your
@@ -38,11 +39,11 @@ In your terminal emulator:
 * Clone this Git repository and start the installation:
 ```sh
 # Make a directory to keep the RexBox files, clone repository in it
-$ mkdir ~/rexbox
-$ cd ~/rexbox
+$ cd
 $ git clone git@github.com:rexich/rexbox.git
 
 # Install necessities
+$ cd ~/rexbox
 $ ./install
 
 # Get inside the machine and start working :)
@@ -58,7 +59,8 @@ $ rxh
 
 ## MIT License
 
-Copyright (c) 2017 Filip Dimovski, portions Copyright (c) 2017 Igor Šarčević
+Copyright (c) 2017 Filip Dimovski
+Portions Copyright (c) 2017 Igor Šarčević
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/install
+++ b/install
@@ -14,18 +14,25 @@ echo -e "\
 \n\
 […] Performing checks..."
 
-if ! [ -f "./helpers.sh" ]; then
-  echo "[!] Helper script missing. Aborting."
-  exit 1
+if ! [ -d ~/rexbox ] ; then
+  echo "[!] RexBox directory is missing. Clone the Git repository in your home folder:"
+  echo "    $ git clone git@github.com:rexich/rexbox.git"
+  echo "    and then run this script from inside the ~/rexbox directory."
+  exit 0
 fi
 
-source "./helpers.sh"
+cd ~/rexbox/installations/
 
-[ -d ~/rexbox ] && bye "[✓] RexBox is already installed.\n\
-    Remove ~/rexbox directory from the home folder and run the \
-script again."
-
-cd installations/
-
+echo "[>] Setting up necessary programs..."
 bash virtualbox.sh
 bash vagrant.sh
+
+echo -n "[>] Setting up aliases in Bash profile..."
+echo 'alias rxb="cd ~/rexbox && vagrant up && vagrant ssh -c \"tmux -2\""' >> ~/.bashrc
+echo 'alias rxh="cd ~/rexbox && vagrant halt"' >> ~/.bashrc
+echo "done."
+
+echo -e "[✓] RexBox installation complete.\n\
+To start using RexBox, type 'rxb' to boot it up and SSH inside it.\n\
+To stop the machine, type 'rxh' in your terminal.\n\
+Thank you for using RexBox. I hope it will suit you well. :)"

--- a/installations/vagrant.sh
+++ b/installations/vagrant.sh
@@ -19,5 +19,7 @@ else
     "https://releases.hashicorp.com/vagrant/1.9.1/vagrant_1.9.1_x86_64.deb"
   sudo dpkg -i /tmp/vagrant_1.9.1_x86_64.deb
   rm /tmp/vagrant_1.9.1_x86_64.deb
+  # Install Vagrant host manager plugin
+  vagrant plugin install vagrant-hostmanager
   echo "[✓] Installation of Vagrant is complete."
 fi

--- a/provisioning/docker.sh
+++ b/provisioning/docker.sh
@@ -18,11 +18,10 @@ else
   sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 \
     --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
   # Install Docker Engine
-  sudo apt-get install docker-engine
-  sudo service docker start
+  sudo apt-get install -y docker-engine
   # Install Docker Compose
   sudo curl -L "https://github.com/docker/compose/releases/download/1.9.0/docker-compose-$(uname -s)-$(uname -m)" \
-    -o /usr/local/bin/docker-compose
+    -o /usr/local/bin/docker-compose 2>&1 > /dev/null
   sudo chmod +x /usr/local/bin/docker-compose
   echo "[✓] Installation of Docker and Docker Compose is complete."
 fi


### PR DESCRIPTION
README.md: tiny fixes; remove superfluous message about sudo;
install: expect the directory to be ~/rexbox; add Bash aliases; short
usage explanation at end of install;
installations/vagrant.sh: install Vagrant host manager plugin;
provisioning/docker.sh: add forgotten -y to automate docker-engine
installation and prevent its failure; avoid curl gibberish output;
